### PR TITLE
Fix demo file paths

### DIFF
--- a/llm_video_generation/src/image.py
+++ b/llm_video_generation/src/image.py
@@ -196,7 +196,8 @@ class ImageSetService:
 
 
 if __name__ == "__main__":
-    scenario = json.load(open("./modules/a.txt", encoding="utf-8"))
+    # サンプルシナリオはモジュール内の a.txt を利用する
+    scenario = json.load(open("./llm_video_generation/src/a.txt", encoding="utf-8"))
     service = ImageSetService()
     urls = service.scenario_to_images(scenario)
 

--- a/llm_video_generation/src/voice.py
+++ b/llm_video_generation/src/voice.py
@@ -194,7 +194,8 @@ class TTSPipeline:
 # --------------------------------------------------------------------------- #
 
 if __name__ == "__main__":
-    scenario_path = Path("./src/llm_video_generation/a.txt")
+    # サンプルシナリオのパスをプロジェクト構成に合わせて修正
+    scenario_path = Path("./llm_video_generation/src/a.txt")
     scenario = json.loads(scenario_path.read_text(encoding="utf-8"))
 
     char_style = {


### PR DESCRIPTION
## Summary
- fix sample file paths in VoiceVox demo
- fix sample file paths in image fetching demo

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1d387148327b49a6eee84b64516